### PR TITLE
FIX: undefined object when inputing empty line

### DIFF
--- a/js/jqTerminal.js
+++ b/js/jqTerminal.js
@@ -126,10 +126,13 @@ var Terminal = function (user, prompt,container) {
 		{
 		   event.preventDefault(); // Do not insert a newline. Instead, let us handle the event.		  
 		   var commandQuery = getCommandInput().trim();
+		   var splitCommand;
 		   if(commandQuery != "")
 		   {
-			  var splitCommand = commandQuery.split(" ");
+			  splitCommand = commandQuery.split(" ");
 			  executeCommand(splitCommand[0],splitCommand);
+		   } else {
+			  splitCommand = [commandQuery];
 		   }
 		  
 		  if(splitCommand[0].indexOf("clear") == -1)


### PR DESCRIPTION
`splitCommand` wasn't declared at all if `commandQuery` is empty, leading to an undefined object reference error when trying to determine if the line is `"clear"`.

But it never could be "clear" if it's empty, so maybe it's better to test that inside de `if` body...
